### PR TITLE
Enable property replacement in persistence.xml

### DIFF
--- a/shared/wildfly/14/standalone-full.xml
+++ b/shared/wildfly/14/standalone-full.xml
@@ -168,7 +168,7 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:discovery:1.0"/>
         <subsystem xmlns="urn:jboss:domain:ee:4.0">
-            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <spec-descriptor-property-replacement>true</spec-descriptor-property-replacement>
             <concurrent>
                 <context-services>
                     <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>


### PR DESCRIPTION
- This enables use of variables in persistence.xml.
- Refer https://docs.jboss.org/author/display/WFLY/Subsystem+configuration for more details