### PR TITLE
Use standalone-full.xml right from the start

### DIFF
--- a/shared/misc/init_container.sh
+++ b/shared/misc/init_container.sh
@@ -78,8 +78,9 @@ do
 done
 
 # Start Wildfly management server in the background. This helps us to proceed with the next steps like waiting for the server to be ready to run the startup script, etc
+# Also, use the standalone-full.xml config (Java EE full-profile)
 echo ***Starting Wildfly in the background...
-$JBOSS_HOME/bin/standalone.sh -b 0.0.0.0 --admin-only &
+$JBOSS_HOME/bin/standalone.sh --server-config=standalone-full.xml -b 0.0.0.0 --admin-only &
 
 function wait_for_server() {
   until `$JBOSS_HOME/bin/jboss-cli.sh -c ":read-attribute(name=server-state)" 2> /dev/null | grep -q running`; do
@@ -161,7 +162,7 @@ fi
 # END: Process startup file / startup command, if any
 
 echo ***Starting JBOSS application server
-$JBOSS_HOME/bin/jboss-cli.sh -c "reload --server-config=standalone-full.xml"
+$JBOSS_HOME/bin/jboss-cli.sh -c "reload"
 
 # Now that we are done with all the steps, bring Wildfly to the foreground again before exiting. If we don't do this, the container will exit after the script exits which we don't want
 echo ***Container initialization complete, now we bring Wildfly to foreground...


### PR DESCRIPTION
- standalone.xml loads the JavEE web profile while standalone-full.xml loads the JavaEE full profile, which is what we want to use
- However, earlier the management server was started with standalone.xml and at the time of starting the application server it would reload using standalone-full.xml
- This led to obvious problems as at the time the startup script was run, the full profile wasn't loaded and would fail to run some JBoss CLI commands. The same commands would work fine when run after the application server was started as by that time the config in use would be standalone-full.xml.
- This commit fixes this issue by using standalone-full.xml at the time of starting up the management server. This way we don't have to specify the config file to be used when we do a reload.