### PR TITLE
Add support for EAR deployments

### DIFF
--- a/shared/appservice/init_container.sh
+++ b/shared/appservice/init_container.sh
@@ -73,20 +73,6 @@ echo "cd /home" >> /etc/profile
 
 # END: Configure /etc/profile
 
-# Copy wardeployed apps to local location and create marker file for each
-for dirpath in /home/site/wwwroot/webapps/*
-do
-    dir="$(basename -- $dirpath)"
-
-    echo ***Copying $dirpath to $JBOSS_HOME/standalone/deployments/$dir.war
-    cp -r $dirpath $JBOSS_HOME/standalone/deployments/$dir.war
-
-    markerfile=$JBOSS_HOME/standalone/deployments/$dir.war.dodeploy
-
-    echo ***Creating marker file $markerfile
-    echo $dir > $markerfile
-done
-
 # Start Wildfly management server in the background. This helps us to proceed with the next steps like waiting for the server to be ready to run the startup script, etc
 # Also, use the standalone-full.xml config (Java EE full-profile)
 echo ***Starting Wildfly in the background...
@@ -102,6 +88,34 @@ function wait_for_server() {
 echo ***Waiting for admin server to be ready
 wait_for_server
 echo ***Admin server is ready
+
+# Copy wardeployed apps to local location and create marker file for each
+if [ -f /home/site/wwwroot/app.ear ]
+then
+    echo "Found app.ear in /home/site/wwwroot, deploying it"
+    ln -s /home/site/wwwroot/app.ear /tmp/wildfly/appservice/ROOT.ear
+    $JBOSS_HOME/bin/jboss-cli.sh -c "deploy /tmp/wildfly/appservice/ROOT.ear"
+elif [ -f /home/site/wwwroot/app.war ]
+then
+    echo "Found app.war in /home/site/wwwroot, deploying it"
+    ln -s /home/site/wwwroot/app.war /tmp/wildfly/appservice/ROOT.war
+    $JBOSS_HOME/bin/jboss-cli.sh -c "deploy /tmp/wildfly/appservice/ROOT.war"
+else
+    echo "Found neither app.ear nor app.war in /home/site/wwwroot, deploying apps in /home/site/wwwroot/webapps if any"
+
+    for dirpath in /home/site/wwwroot/webapps/*
+    do
+        dir="$(basename -- $dirpath)"
+
+        echo ***Copying $dirpath to $JBOSS_HOME/standalone/deployments/$dir.war
+        cp -r $dirpath $JBOSS_HOME/standalone/deployments/$dir.war
+
+        markerfile=$JBOSS_HOME/standalone/deployments/$dir.war.dodeploy
+
+        echo ***Creating marker file $markerfile
+        echo $dir > $markerfile
+    done
+fi
 
 # EasyAuth setup (Let the EasyAuth jar decide whether to install or skip the EasyAuth filter)
 $JBOSS_HOME/bin/jboss-cli.sh -c --file=/tmp/wildfly/appservice/lib/azure.appservice.easyauth.cli


### PR DESCRIPTION
- This commit adds support for deploying EAR files.
- Also, new convention is introduced for deployments. Specifically, this is the new deployment order:
   1. /home/site/wwwwroot/app.ear
   2. /home/site/wwwroot/app.war
   3. Apps in /home/site/wwwroot/webapps/*